### PR TITLE
Cache whole credential chain, not just final creds

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscreds "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/pkg/errors"
+)
+
+type result struct {
+	Version int
+	sts.Credentials
+}
+
+func (this result) Expiry() *time.Time {
+	return this.Expiration
+}
+
+func fetchAWSCredentials(arn, token, sessionName string) (*result, error) {
+
+	input := sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          &arn,
+		RoleSessionName:  &sessionName,
+		WebIdentityToken: &token,
+	}
+
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating aws session")
+	}
+
+	svc := sts.New(sess)
+	output, err := svc.AssumeRoleWithWebIdentity(&input)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("error assuming role %q with web identity", arn))
+	}
+
+	result := result{
+		Version:     1,
+		Credentials: *output.Credentials,
+	}
+
+	return &result, nil
+}
+
+func assumeRole(arn, sessionName string, credentials *result) (*result, error) {
+
+	input := sts.AssumeRoleInput{
+		RoleArn:         &arn,
+		RoleSessionName: &sessionName,
+	}
+
+	sess, err := session.NewSession(
+		aws.NewConfig().WithCredentials(
+			awscreds.NewStaticCredentials(
+				*credentials.Credentials.AccessKeyId,
+				*credentials.Credentials.SecretAccessKey,
+				*credentials.Credentials.SessionToken,
+			)))
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating aws session")
+	}
+
+	svc := sts.New(sess)
+	output, err := svc.AssumeRole(&input)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("error assuming role %q", arn))
+	}
+
+	result := result{
+		Version:     1,
+		Credentials: *output.Credentials,
+	}
+
+	return &result, nil
+}
+
+type signinSession struct {
+	SessionId    string `json:"sessionId"`
+	SessionKey   string `json:"sessionKey"`
+	SessionToken string `json:"sessionToken"`
+}
+
+type signinToken struct {
+	SigninToken string
+}
+
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
+func fetchSigninToken(result *result) error {
+
+	sessionData := signinSession{
+		SessionId:    *result.Credentials.AccessKeyId,
+		SessionKey:   *result.Credentials.SecretAccessKey,
+		SessionToken: *result.Credentials.SessionToken,
+	}
+
+	b, err := json.Marshal(sessionData)
+
+	if err != nil {
+		return errors.Wrap(err, "failed to encode signin json data")
+	}
+
+	tokenURL := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=getSigninToken&Session=%s", url.QueryEscape(string(b)))
+
+	resp, err := http.DefaultClient.Get(tokenURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch signin token for credentials")
+	} else if resp.StatusCode != 200 {
+		return fmt.Errorf("getSigninToken returned %d instead of 200", resp.StatusCode)
+	}
+
+	buffer := new(bytes.Buffer)
+	buffer.ReadFrom(resp.Body)
+	token := signinToken{}
+	err = json.Unmarshal(buffer.Bytes(), &token)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode getSigninToken response")
+	}
+
+	destination := "https://console.aws.amazon.com/"
+
+	loginUrl := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=login&Destination=%s&SigninToken=%s",
+		url.QueryEscape(destination),
+		token.SigninToken,
+	)
+
+	if err := openInBrowser(loginUrl); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,31 +1,18 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/aws/aws-sdk-go/aws"
-	awscreds "github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
-	"golang.org/x/oauth2"
 )
 
 type oidcConfig struct {
@@ -43,377 +30,20 @@ type alias struct {
 	RoleChain  []string
 }
 
-type idTokenResult struct {
-	rawToken string
-	token    *oidc.IDToken
-	email    string
-	sub      string
-}
-
-type idTokenMessage struct {
-	result idTokenResult
-	err    error
-}
-
 var envFormat = flag.Bool("env", false, "output credentials in format suitable for use with $()")
 
 var loginFormat = flag.Bool("login", false, "generate login link for AWS web console")
+
+var verbose = flag.Bool("verbose", false, "log verbose/debug output")
 
 var sourceRole = flag.String("sourcerole", "", "source role to assume before assuming target role")
 
 var aliasFlag = flag.String("alias", "", "alias configured in ~/.oidc2aws/oidcconfig")
 
-var oc = oidcConfig{}
-
-func openInBrowser(url string) error {
-	cmd := exec.Command("open", url)
-	return errors.Wrap(cmd.Run(), "error opening page in browser")
-}
-
-func fetchIDToken() (*idTokenResult, error) {
-	ctx := context.Background()
-
-	provider, err := oidc.NewProvider(ctx, oc.Provider)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating oidc provider")
-	}
-
-	redirectURL := "http://localhost:9999/code"
-
-	// Configure an OpenID Connect aware OAuth2 client.
-	oauth2Config := oauth2.Config{
-		ClientID:     oc.ClientID,
-		ClientSecret: oc.ClientSecret,
-		RedirectURL:  redirectURL,
-
-		// Discovery returns the OAuth2 endpoints.
-		Endpoint: provider.Endpoint(),
-
-		// "openid" is a required scope for OpenID Connect flows.
-		Scopes: []string{oidc.ScopeOpenID, "email"},
-	}
-
-	var rawState [40]byte
-
-	_, err = rand.Read(rawState[:])
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error generating oauth state")
-	}
-
-	state := hex.EncodeToString(rawState[:])
-
-	url := oauth2Config.AuthCodeURL(state,
-		oauth2.SetAuthURLParam("hd", oc.HostedDomain),
-
-		// If this is set, or if the user actually needs to
-		// authenticate, we aren't able to automatically close the
-		// browser window after authentication :(
-		// oauth2.SetAuthURLParam("prompt", "consent")
-	)
-
-	if err := openInBrowser(url); err != nil {
-		return nil, err
-	}
-
-	server := http.Server{
-		Addr: ":9999",
-	}
-	server.SetKeepAlivesEnabled(false)
-
-	requestSignal := make(chan idTokenMessage)
-	serverSignal := make(chan idTokenMessage)
-
-	server.Handler = handleOAuth2Callback(provider, oauth2Config, state, requestSignal)
-
-	go func() {
-		result := <-requestSignal
-
-		err := server.Shutdown(ctx)
-
-		if err != nil {
-			result = idTokenMessage{
-				err: errors.Wrap(err, "error on server shutdown"),
-			}
-		}
-
-		serverSignal <- result
-	}()
-
-	err = server.ListenAndServe()
-
-	if err != nil && err != http.ErrServerClosed {
-		return nil, errors.Wrap(err, "error from server.ListenAndServe")
-	}
-
-	result := <-serverSignal
-
-	if result.err != nil {
-		return nil, err
-	}
-
-	return &result.result, nil
-}
-
-func writeError(w http.ResponseWriter, err error, msg string) error {
-	if err == nil {
-		err = errors.New(msg)
-	} else {
-		err = errors.Wrap(err, msg)
-	}
-
-	w.WriteHeader(500)
-	writeString(w, fmt.Sprintf("%v", err))
-
-	return err
-}
-
-func handleOAuth2Callback(provider *oidc.Provider, oauth2Config oauth2.Config, state string, signal chan idTokenMessage) http.HandlerFunc {
-
-	verifier := provider.Verifier(&oidc.Config{ClientID: oauth2Config.ClientID})
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Verify request state matches response state
-		reqState := r.URL.Query().Get("state")
-		if reqState != state {
-			signal <- idTokenMessage{err: writeError(w, nil, "response state does not match request state")}
-			return
-		}
-
-		// Exchange authorisation code for access/id token
-		oauth2Token, err := oauth2Config.Exchange(r.Context(), r.URL.Query().Get("code"))
-		if err != nil {
-			signal <- idTokenMessage{err: writeError(w, err, "error exchanging authorisation code for access/id tokens")}
-			return
-		}
-
-		// Extract ID Token from OAuth2 token.
-		rawIDToken, ok := oauth2Token.Extra("id_token").(string)
-		if !ok {
-			signal <- idTokenMessage{err: writeError(w, nil, "no id_token included when fetching access token")}
-			return
-		}
-
-		// Parse and verify ID Token payload.
-		idToken, err := verifier.Verify(r.Context(), rawIDToken)
-		if err != nil {
-			signal <- idTokenMessage{err: writeError(w, err, "error verifying id token")}
-			return
-		}
-
-		// Extract custom claim
-		var claims struct {
-			Email   string `json:"email"`
-			Subject string `json:"sub"`
-		}
-		err = idToken.Claims(&claims)
-		if err != nil {
-			signal <- idTokenMessage{err: writeError(w, err, "error extracting claims from id token")}
-			return
-		}
-
-		// Pass result back
-		signal <- idTokenMessage{
-			result: idTokenResult{
-				rawToken: rawIDToken,
-				token:    idToken,
-				email:    claims.Email,
-				sub:      claims.Subject,
-			},
-		}
-
-		// Close the browser window
-		writeString(w, "<script>window.close()</script>")
-	}
-}
-
-func writeString(w http.ResponseWriter, s string) {
-	// <link> is to prevent browsers trying to load a favicon for this page
-	w.Write([]byte(`<!DOCTYPE html><html><link rel="icon" href="data:;base64,iVBORw0KGgo="><body>` + s))
-
-}
-
-type result struct {
-	Version int
-	sts.Credentials
-}
-
-func fetchAWSCredentials(arn, token, sessionName string) (*result, error) {
-
-	input := sts.AssumeRoleWithWebIdentityInput{
-		RoleArn:          &arn,
-		RoleSessionName:  &sessionName,
-		WebIdentityToken: &token,
-	}
-
-	sess, err := session.NewSession()
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating aws session")
-	}
-
-	svc := sts.New(sess)
-	output, err := svc.AssumeRoleWithWebIdentity(&input)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error assuming role %q with web identity", arn))
-	}
-
-	result := result{
-		Version:     1,
-		Credentials: *output.Credentials,
-	}
-
-	bytes, err := json.Marshal(result)
-	if err != nil {
-		return nil, errors.Wrap(err, "error serialising credentials to json")
-	}
-
-	filename := arnFilename(arn)
-
-	err = ioutil.WriteFile(filename, bytes, 0600)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error writing credentials to file %q", filename))
-	}
-
-	return &result, nil
-}
-
-func assumeRole(arn, sessionName string, credentials *result) (*result, error) {
-
-	input := sts.AssumeRoleInput{
-		RoleArn:         &arn,
-		RoleSessionName: &sessionName,
-	}
-
-	sess, err := session.NewSession(
-		aws.NewConfig().WithCredentials(
-			awscreds.NewStaticCredentials(
-				*credentials.Credentials.AccessKeyId,
-				*credentials.Credentials.SecretAccessKey,
-				*credentials.Credentials.SessionToken,
-			)))
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating aws session")
-	}
-
-	svc := sts.New(sess)
-	output, err := svc.AssumeRole(&input)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error assuming role %q", arn))
-	}
-
-	result := result{
-		Version:     1,
-		Credentials: *output.Credentials,
-	}
-
-	bytes, err := json.Marshal(result)
-	if err != nil {
-		return nil, errors.Wrap(err, "error serialising credentials to json")
-	}
-
-	filename := arnFilename(arn)
-
-	err = ioutil.WriteFile(filename, bytes, 0600)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error writing credentials to file %q", filename))
-	}
-
-	return &result, nil
-}
-
 func arnFilename(arn string) string {
 	arn = strings.Replace(arn, "/", "-", -1)
 	arn = strings.Replace(arn, ":", "-", -1)
 	return path.Join(os.Getenv("HOME"), ".oidc2aws", arn)
-}
-
-func credentialsForRole(arn string) (*result, error) {
-	result := result{}
-
-	filename := arnFilename(arn)
-
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-
-		return nil, errors.Wrap(err, fmt.Sprintf("error reading credential cache file %q", filename))
-	}
-
-	err = json.Unmarshal(data, &result)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error decoding credential cache from file %q", filename))
-	}
-
-	// check token expires > 5 minutes from now
-	if result.Expiration == nil {
-		return nil, nil
-	} else if (*result.Expiration).Add(-5 * time.Minute).Before(time.Now()) {
-		err := os.Remove(filename)
-		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("error removing expired credentials in file %q", filename))
-		}
-		return nil, err
-	}
-
-	return &result, nil
-}
-
-type signinSession struct {
-	SessionId    string `json:"sessionId"`
-	SessionKey   string `json:"sessionKey"`
-	SessionToken string `json:"sessionToken"`
-}
-
-type signinToken struct {
-	SigninToken string
-}
-
-// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
-func fetchSigninToken(result *result) error {
-
-	sessionData := signinSession{
-		SessionId:    *result.Credentials.AccessKeyId,
-		SessionKey:   *result.Credentials.SecretAccessKey,
-		SessionToken: *result.Credentials.SessionToken,
-	}
-
-	b, err := json.Marshal(sessionData)
-
-	if err != nil {
-		return errors.Wrap(err, "failed to encode signin json data")
-	}
-
-	tokenURL := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=getSigninToken&Session=%s", url.QueryEscape(string(b)))
-
-	resp, err := http.DefaultClient.Get(tokenURL)
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch signin token for credentials")
-	} else if resp.StatusCode != 200 {
-		return fmt.Errorf("getSigninToken returned %d instead of 200", resp.StatusCode)
-	}
-
-	buffer := new(bytes.Buffer)
-	buffer.ReadFrom(resp.Body)
-	token := signinToken{}
-	err = json.Unmarshal(buffer.Bytes(), &token)
-	if err != nil {
-		return errors.Wrap(err, "failed to decode getSigninToken response")
-	}
-
-	destination := "https://console.aws.amazon.com/"
-
-	loginUrl := fmt.Sprintf("https://signin.aws.amazon.com/federation?Action=login&Destination=%s&SigninToken=%s",
-		url.QueryEscape(destination),
-		token.SigninToken,
-	)
-
-	if err := openInBrowser(loginUrl); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func printCredentials(result *result) error {
@@ -437,24 +67,33 @@ func printCredentials(result *result) error {
 	return err
 }
 
+var debug = func(_ ...interface{}) {}
+var debugf = func(_ string, _ ...interface{}) {}
+
 func main() {
+	oc := oidcConfig{}
+
 	if _, err := toml.DecodeFile(path.Join(os.Getenv("HOME"), ".oidc2aws", "oidcconfig"), &oc); err != nil {
 		log.Fatal(errors.Wrap(err, "error loading OIDC config"))
 	}
 
 	flag.Parse()
 
+	if *verbose {
+		debug = log.Println
+		debugf = log.Printf
+	}
+
 	args := flag.Args()
 
-	initialRole := ""
 	roles := []string{}
 
 	// 1. len(args) == 1 => initialRole = args[0]
-	// 2. len(args) == 1, sourceRole != nil => initialRole = *sourceRole, roles = args <= legacy
-	// 3. alias(arn) => initialRole = arn, roles = []
-	// 4. alias(arn, sourceRole) => initialRole = sourceRole, roles = [arn] <= legacy
-	// 5. alias(rolechain) => initialRole = rolechain[0], roles = rolechain[1:]
-	// 5. len(args) > 1 => initialRole = args[0], roles = args[1:]
+	// 2. len(args) == 1, sourceRole != nil => roles = [sourceRole, ...args] <= legacy
+	// 3. alias(arn) => roles = [arn]
+	// 4. alias(arn, sourceRole) => initialRole = sourceRole, roles = [sourceRole, arn] <= legacy
+	// 5. alias(rolechain) => roles = rolechain
+	// 5. len(args) > 1 => roles = args
 
 	if *aliasFlag != "" {
 		alias, ok := oc.Alias[*aliasFlag]
@@ -462,67 +101,199 @@ func main() {
 			log.Fatalf("unknown alias: %s", *aliasFlag)
 		}
 		if len(alias.RoleChain) > 0 {
-			initialRole = alias.RoleChain[0]
-			roles = alias.RoleChain[1:]
+			roles = alias.RoleChain
 		} else {
-			initialRole = alias.Arn
 			if alias.SourceRole != "" {
-				roles = []string{alias.SourceRole}
+				roles = []string{alias.SourceRole, alias.Arn}
+			} else {
+				roles = []string{alias.Arn}
 			}
 		}
 	} else if *sourceRole != "" {
-		initialRole = *sourceRole
-		roles = args
+		roles = []string{*sourceRole}
+		roles = append(roles, args...)
 	} else {
 		if len(args) > 0 {
-			initialRole = args[0]
-			roles = args[1:]
+			roles = args
 		}
 	}
 
-	if initialRole == "" {
-		log.Fatal("no arn provided in Args[1] or alias")
+	if len(roles) == 0 {
+		log.Fatal("no roles provided, please add roles as args or use -alias")
 	}
 
-	// Check for AWS credentials for role, use them if not expired
-	finalRole := initialRole
-	if len(roles) > 0 {
-		finalRole = roles[len(roles)-1]
+	var r fetcher = cache{oidcFetcher{arn: roles[0], oc: oc}}
+	for _, role := range roles[1:] {
+		r = cache{assumedRole{arn: role, upstream: r}}
 	}
-	result, err := credentialsForRole(finalRole)
+
+	result, err := r.fetchCredentials()
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "error reading credentials for role"))
-	} else if result != nil {
-		err := printCredentials(result)
-		if err != nil {
-			log.Fatal(err)
-		}
-		return
-	}
-
-	// Check for ID Token, use it if not expired
-	// Fetch ID token
-	// Cache ID token
-	// Fetch AWS credentials
-
-	idToken, err := fetchIDToken()
-	if err != nil {
-		log.Fatal(errors.Wrap(err, "error fetching id token"))
-	}
-
-	result, err = fetchAWSCredentials(initialRole, idToken.rawToken, idToken.email)
-	if err != nil {
-		log.Fatal(errors.Wrap(err, fmt.Sprintf(`error fetching aws credentials (is %q an allowed value for "accounts.google.com:sub" in Trust relationship conditions for role?)`, idToken.sub)))
-	}
-
-	for _, role := range roles {
-		result, err = assumeRole(role, idToken.email+","+*result.Credentials.AccessKeyId, result)
-		if err != nil {
-			log.Fatal(err)
-		}
+		log.Fatal(err)
 	}
 
 	if err := printCredentials(result); err != nil {
 		log.Fatal(errors.Wrap(err, "error printing credentials"))
 	}
+}
+
+type fetcher interface {
+	fetchCredentials() (*result, error)
+}
+
+type cacheable interface {
+	key() string
+}
+
+type expiring interface {
+	Expiry() *time.Time
+}
+
+type assumedRole struct {
+	arn      string
+	upstream fetcher
+}
+
+func (this assumedRole) fetchCredentials() (*result, error) {
+	debugf("assuming role %s", this.arn)
+	result, err := this.upstream.fetchCredentials()
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching credentials from upstream")
+	} else if result == nil {
+		return nil, errors.Wrap(err, "upstream didn't return credentials")
+	}
+
+	//	return assumeRole(this.arn, idToken.email+","+*result.Credentials.AccessKeyId, result)
+	return assumeRole(this.arn, *result.Credentials.AccessKeyId, result)
+}
+
+func (this assumedRole) key() string {
+	return this.arn
+}
+
+type oidcFetcher struct {
+	oc  oidcConfig
+	arn string
+}
+
+func (this oidcFetcher) fetchCredentials() (*result, error) {
+	idToken := &idTokenResult{}
+	key := "id-token"
+	err := get(key, idToken)
+	if err != nil && err != errNotFound {
+		return nil, errors.Wrap(err, "error reading cached file")
+	}
+
+	if err == errNotFound {
+		debug("no cached id token, fetching...")
+		del(key)
+		idToken, err = fetchIDToken(this.oc)
+		if err != nil {
+			return nil, errors.Wrap(err, "error fetching id token")
+		}
+
+		put(key, idToken)
+		if err != nil {
+			return nil, errors.Wrap(err, "error caching id token")
+		}
+	} else {
+		debug("using cached id token...")
+	}
+
+	debugf("swapping id token for credentials for role %s...", this.arn)
+	result, err := fetchAWSCredentials(this.arn, idToken.RawToken, idToken.Email)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(`error fetching aws credentials (is %q an allowed value for "accounts.google.com:sub" in Trust relationship conditions for role?)`, idToken.Sub))
+	}
+	return result, err
+}
+
+func (this oidcFetcher) key() string {
+	return this.arn
+}
+
+type cacheableFetcher interface {
+	cacheable
+	fetcher
+}
+
+type cache struct {
+	f cacheableFetcher
+}
+
+func (this cache) fetchCredentials() (*result, error) {
+	key := this.f.key()
+
+	// Check for AWS credentials for role, use them if not expired (cache checks expiry)
+	result := &result{}
+	err := get(key, result)
+	if err == nil {
+		debugf("have cached credentials for %s", key)
+
+		return result, err
+	} else if err != errNotFound {
+		return nil, errors.Wrap(err, "error reading cached credentials for role")
+	}
+
+	debugf("no cached credentials for %s, fetching...", key)
+	result, err = this.f.fetchCredentials()
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching credentials")
+	}
+
+	put(key, result)
+	if err != nil {
+		return nil, errors.Wrap(err, "error caching credentials")
+	}
+
+	return result, err
+}
+
+func put(key string, val interface{}) error {
+	debugf("writing credentials for %s to cache", key)
+
+	bytes, err := json.Marshal(val)
+	if err != nil {
+		return errors.Wrap(err, "error serialising credentials to json")
+	}
+
+	err = ioutil.WriteFile(arnFilename(key), bytes, 0600)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error writing credentials to file %q", key))
+	}
+
+	return nil
+}
+
+var errNotFound = errors.New("no value for key")
+
+func get(key string, val interface{}) error {
+	debugf("fetching cached credentials for %s...", key)
+	data, err := ioutil.ReadFile(arnFilename(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errNotFound
+		}
+
+		return errors.Wrap(err, fmt.Sprintf("error reading credential cache file %q", key))
+	}
+
+	err = json.Unmarshal(data, &val)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error decoding credential cache from file %q", key))
+	}
+
+	exp, ok := val.(expiring)
+	debugf("credentials expire at %v", exp.Expiry())
+	if expiry := exp.Expiry(); ok && (expiry == nil || exp.Expiry().Add(-5*time.Minute).Before(time.Now())) {
+		debug("credentials nil or expiring in less than 5 minutes")
+		del(key)
+		return errNotFound
+	}
+
+	return nil
+}
+
+func del(key string) error {
+	return os.Remove(arnFilename(key))
 }

--- a/oidc.go
+++ b/oidc.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/coreos/go-oidc"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+)
+
+type idTokenResult struct {
+	RawToken string
+	Token    *oidc.IDToken
+	Email    string
+	Sub      string
+}
+
+func (this idTokenResult) Expiry() *time.Time {
+	return &this.Token.Expiry
+}
+
+type idTokenMessage struct { // One of (either)...
+	result idTokenResult // a result, or
+	err    error         // an error
+}
+
+func openInBrowser(url string) error {
+	cmd := exec.Command("open", url)
+	return errors.Wrap(cmd.Run(), "error opening page in browser")
+}
+
+func fetchIDToken(oc oidcConfig) (*idTokenResult, error) {
+	ctx := context.Background()
+
+	provider, err := oidc.NewProvider(ctx, oc.Provider)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating oidc provider")
+	}
+
+	redirectURL := "http://localhost:9999/code"
+
+	// Configure an OpenID Connect aware OAuth2 client.
+	oauth2Config := oauth2.Config{
+		ClientID:     oc.ClientID,
+		ClientSecret: oc.ClientSecret,
+		RedirectURL:  redirectURL,
+
+		// Discovery returns the OAuth2 endpoints.
+		Endpoint: provider.Endpoint(),
+
+		// "openid" is a required scope for OpenID Connect flows.
+		Scopes: []string{oidc.ScopeOpenID, "email"},
+	}
+
+	var rawState [40]byte
+
+	_, err = rand.Read(rawState[:])
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating oauth state")
+	}
+
+	state := hex.EncodeToString(rawState[:])
+
+	url := oauth2Config.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("hd", oc.HostedDomain),
+
+		// If this is set, or if the user actually needs to
+		// authenticate, we aren't able to automatically close the
+		// browser window after authentication :(
+		// oauth2.SetAuthURLParam("prompt", "consent")
+	)
+
+	if err := openInBrowser(url); err != nil {
+		return nil, err
+	}
+
+	server := http.Server{
+		Addr: ":9999",
+	}
+	server.SetKeepAlivesEnabled(false)
+
+	requestSignal := make(chan idTokenMessage)
+	serverSignal := make(chan idTokenMessage)
+
+	server.Handler = handleOAuth2Callback(provider, oauth2Config, state, requestSignal)
+
+	go func() {
+		result := <-requestSignal
+
+		err := server.Shutdown(ctx)
+
+		if err != nil {
+			result = idTokenMessage{
+				err: errors.Wrap(err, "error on server shutdown"),
+			}
+		}
+
+		serverSignal <- result
+	}()
+
+	err = server.ListenAndServe()
+
+	if err != nil && err != http.ErrServerClosed {
+		return nil, errors.Wrap(err, "error from server.ListenAndServe")
+	}
+
+	result := <-serverSignal
+
+	if result.err != nil {
+		return nil, err
+	}
+
+	return &result.result, nil
+}
+
+func writeError(w http.ResponseWriter, err error, msg string) error {
+	if err == nil {
+		err = errors.New(msg)
+	} else {
+		err = errors.Wrap(err, msg)
+	}
+
+	w.WriteHeader(500)
+	writeString(w, fmt.Sprintf("%v", err))
+
+	return err
+}
+
+func handleOAuth2Callback(provider *oidc.Provider, oauth2Config oauth2.Config, state string, signal chan idTokenMessage) http.HandlerFunc {
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: oauth2Config.ClientID})
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Verify request state matches response state
+		reqState := r.URL.Query().Get("state")
+		if reqState != state {
+			signal <- idTokenMessage{err: writeError(w, nil, "response state does not match request state")}
+			return
+		}
+
+		// Exchange authorisation code for access/id token
+		oauth2Token, err := oauth2Config.Exchange(r.Context(), r.URL.Query().Get("code"))
+		if err != nil {
+			signal <- idTokenMessage{err: writeError(w, err, "error exchanging authorisation code for access/id tokens")}
+			return
+		}
+
+		// Extract ID Token from OAuth2 token.
+		rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+		if !ok {
+			signal <- idTokenMessage{err: writeError(w, nil, "no id_token included when fetching access token")}
+			return
+		}
+
+		// Parse and verify ID Token payload.
+		idToken, err := verifier.Verify(r.Context(), rawIDToken)
+		if err != nil {
+			signal <- idTokenMessage{err: writeError(w, err, "error verifying id token")}
+			return
+		}
+
+		// Extract custom claim
+		var claims struct {
+			Email   string `json:"email"`
+			Subject string `json:"sub"`
+		}
+		err = idToken.Claims(&claims)
+		if err != nil {
+			signal <- idTokenMessage{err: writeError(w, err, "error extracting claims from id token")}
+			return
+		}
+
+		// Pass result back
+		signal <- idTokenMessage{
+			result: idTokenResult{
+				RawToken: rawIDToken,
+				Token:    idToken,
+				Email:    claims.Email,
+				Sub:      claims.Subject,
+			},
+		}
+
+		// Close the browser window
+		writeString(w, "<script>window.close()</script>")
+	}
+}
+
+func writeString(w http.ResponseWriter, s string) {
+	// <link> is to prevent browsers trying to load a favicon for this page
+	w.Write([]byte(`<!DOCTYPE html><html><link rel="icon" href="data:;base64,iVBORw0KGgo="><body>` + s))
+
+}


### PR DESCRIPTION
Previously `oidc2aws` would only write the final credentials in the role chain to disk. This gets annoying when working across multiple accounts eg with Terraform. A Terraform plan that used multiple AWS providers would trigger `oidc2aws` for each provider in parallel, but only the first one would work, the others would fail.

This change allows you to "preload" the earlier roles in the chain (including the Google OIDC JWT) so that with a chain like:

```
oidc2aws arn:aws:iam::xxx:role/first-role arn:aws:iam::xxx:role/second-role
```

`oidc2aws` will build a stack of roles to acquire:

```
arn:aws:iam::xxx:role/second-role
arn:aws:iam::xxx:role/first-role
<oidc>
```

then, starting from the top, if there are ~valid~ unexpired cached credentials for the top role (in this case `arn:aws:iam::xxx:role/second-role`), `oidc2aws` will use them directly. Otherwise, it will "pop" the item off, and recursively perform the same process with the next role in the stack:

```
Do we have arn:aws:iam::xxx:role/second-role?
-> Not yet... do we have `arn:aws:iam::xxx:role/first-role`?
   -> Not yet... do we have `<oidc>`?
      -> Not yet... fetch `<oidc>`
      <- Ok, use `<oidc>` to acquire `arn:aws:iam::xxx:role/first-role`
   <- Ok, use `arn:aws:iam::xxx:role/first-role` to acquire `arn:aws:iam::xxx:role/second-role`
<- Ok, we have `arn:aws:iam::xxx:role/second-role`, print and finish
```

It's not great to write all these credentials unencrypted to disk, but they are temporary (1 hour or so), and I don't have time to figure out how to encrypt them right now.