### PR TITLE
Support different shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ $ aws --profile=my-profile sts get-caller-identity
      "SessionToken": "..."
    }
    ```
-2. Env format suitable for setting environment variables in the shell, via `-env` flag
+2. Env format suitable for setting environment variables in the shell, via `-env` flag.
+
+   _Note that the command for setting the environment variables is for the default shell of the current user._
 
    ```
    $ oidc2aws arn:aws:iam::123456789012:role/my-role
@@ -155,6 +157,21 @@ $ aws --profile=my-profile sts get-caller-identity
    AWS_ACCESS_KEY_ID=ASIA...
    AWS_SECRET_ACCESS_KEY=...
    AWS_SESSION_TOKEN=...
+   ```
+
+   If you are using `fish` shell, you can do this instead:
+   ```
+   $ oidc2aws -env arn:aws:iam::123456789012:role/my-role | source
+   ```
+
+   If you are not using the default shell of current user, you can set the shell
+   type explicitly by `-shell` flag:
+
+   ```
+   $ oidc2aws -env -shell csh arn:aws:iam::123456789012:role/my-role
+   setenv AWS_ACCESS_KEY_ID ASIA...
+   setenv AWS_SECRET_ACCESS_KEY ...
+   setenv AWS_SESSION_TOKEN ...
    ```
 
 # `-login`: AWS Console Login

--- a/main.go
+++ b/main.go
@@ -62,11 +62,6 @@ func printCredentials(result *result) error {
 
 		// Check the shell type and print the appropriate command to export the variable
 		switch current_shell {
-		case "bash", "zsh", "sh":
-			// For bash, zsh and sh, use the export command
-			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *result.Credentials.AccessKeyId)
-			fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", *result.Credentials.SecretAccessKey)
-			fmt.Printf("export AWS_SESSION_TOKEN=%s\n", *result.Credentials.SessionToken)
 		case "fish":
 			// For fish, use the set command
 			fmt.Printf("set -x AWS_ACCESS_KEY_ID %s\n", *result.Credentials.AccessKeyId)
@@ -77,9 +72,13 @@ func printCredentials(result *result) error {
 			fmt.Printf("setenv AWS_ACCESS_KEY_ID %s\n", *result.Credentials.AccessKeyId)
 			fmt.Printf("setenv AWS_SECRET_ACCESS_KEY %s\n", *result.Credentials.SecretAccessKey)
 			fmt.Printf("setenv AWS_SESSION_TOKEN %s\n", *result.Credentials.SessionToken)
+		case "bash", "zsh", "sh":
+			fallthrough
 		default:
-			// For other shells, return an error
-			return errors.Errorf("unsupported shell: %s", current_shell)
+			// For bash, zsh, sh and any other shell, use the export command
+			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *result.Credentials.AccessKeyId)
+			fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", *result.Credentials.SecretAccessKey)
+			fmt.Printf("export AWS_SESSION_TOKEN=%s\n", *result.Credentials.SessionToken)
 		}
 
 		return nil

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ var sourceRole = flag.String("sourcerole", "", "source role to assume before ass
 
 var aliasFlag = flag.String("alias", "", "alias configured in ~/.oidc2aws/oidcconfig")
 
+var shell = flag.String("shell", "", "shell type, possible values: bash, zsh, sh, fish, csh, tcsh")
+
 func arnFilename(arn string) string {
 	arn = strings.Replace(arn, "/", "-", -1)
 	arn = strings.Replace(arn, ":", "-", -1)
@@ -48,11 +50,18 @@ func arnFilename(arn string) string {
 
 func printCredentials(result *result) error {
 	if *envFormat {
-		// Get the name of current shell
-		shell := os.Getenv("SHELL")
+		// Get the name of current user's default shell
+		default_shell := os.Getenv("SHELL")
+
+		current_shell := path.Base(default_shell)
+
+		// If the user has specified a shell, use that instead
+		if *shell != "" {
+			current_shell = *shell
+		}
 
 		// Check the shell type and print the appropriate command to export the variable
-		switch path.Base(shell) {
+		switch current_shell {
 		case "bash", "zsh", "sh":
 			// For bash, zsh and sh, use the export command
 			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *result.Credentials.AccessKeyId)
@@ -70,7 +79,7 @@ func printCredentials(result *result) error {
 			fmt.Printf("setenv AWS_SESSION_TOKEN %s\n", *result.Credentials.SessionToken)
 		default:
 			// For other shells, return an error
-			return errors.Errorf("unsupported shell: %s", shell)
+			return errors.Errorf("unsupported shell: %s", current_shell)
 		}
 
 		return nil

--- a/main.go
+++ b/main.go
@@ -48,9 +48,31 @@ func arnFilename(arn string) string {
 
 func printCredentials(result *result) error {
 	if *envFormat {
-		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *result.Credentials.AccessKeyId)
-		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", *result.Credentials.SecretAccessKey)
-		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", *result.Credentials.SessionToken)
+		// Get the name of current shell
+		shell := os.Getenv("SHELL")
+
+		// Check the shell type and print the appropriate command to export the variable
+		switch path.Base(shell) {
+		case "bash", "zsh", "sh":
+			// For bash, zsh and sh, use the export command
+			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *result.Credentials.AccessKeyId)
+			fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", *result.Credentials.SecretAccessKey)
+			fmt.Printf("export AWS_SESSION_TOKEN=%s\n", *result.Credentials.SessionToken)
+		case "fish":
+			// For fish, use the set command
+			fmt.Printf("set -x AWS_ACCESS_KEY_ID %s\n", *result.Credentials.AccessKeyId)
+			fmt.Printf("set -x AWS_SECRET_ACCESS_KEY %s\n", *result.Credentials.SecretAccessKey)
+			fmt.Printf("set -x AWS_SESSION_TOKEN %s\n", *result.Credentials.SessionToken)
+		case "csh", "tcsh":
+			// For csh and tcsh, use the setenv command
+			fmt.Printf("setenv AWS_ACCESS_KEY_ID %s\n", *result.Credentials.AccessKeyId)
+			fmt.Printf("setenv AWS_SECRET_ACCESS_KEY %s\n", *result.Credentials.SecretAccessKey)
+			fmt.Printf("setenv AWS_SESSION_TOKEN %s\n", *result.Credentials.SessionToken)
+		default:
+			// For other shells, return an error
+			return errors.Errorf("unsupported shell: %s", shell)
+		}
+
 		return nil
 	} else if *loginFormat {
 		return fetchSigninToken(result)


### PR DESCRIPTION
As a fish shell user, I've found that our project currently only supports the bash style (`export X=Y`) of setting environment variables when I use the `-env` option. The purpose of this PR is to support other common shells.

How to determine which type of shell to use for exporting commands that set environment variables?

1. You can use the `-shell` option to specify the shell type you want explicitly.
2. If `-shell` is not provided, then use the current user's default shell type, which is we can read from the SHELL environment variable.

I _don't_ think you'll need provide the `-shell` option in most cases, unless you're manually entering a shell different from the default, which is rare, and this is the only reason the `-shell` option exist.

Any thoughts? @theplant/sre @bodhi Thank you! :)